### PR TITLE
Fix some linter issues

### DIFF
--- a/api/v1alpha3/groupversion_info.go
+++ b/api/v1alpha3/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha3 contains API Schema definitions for the infrastructure v1alpha3 API group
+// Package v1alpha3 contains API Schema definitions for the infrastructure v1alpha3 API group.
 // +kubebuilder:object:generate=true
 // +groupName=infrastructure.cluster.x-k8s.io
 package v1alpha3
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "infrastructure.cluster.x-k8s.io", Version: "v1alpha3"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/api/v1alpha3/tinkerbellcluster_types.go
+++ b/api/v1alpha3/tinkerbellcluster_types.go
@@ -25,11 +25,11 @@ import (
 
 // TinkerbellClusterSpec defines the desired state of TinkerbellCluster
 // INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-// Important: Run "make" to regenerate code after modifying this file
+// Important: Run "make" to regenerate code after modifying this file.
 type TinkerbellClusterSpec struct {
 	// HardwareDiscoveryStrategy is a switch we have to implement more advacned
 	// discovery strategy. The unique one we have today is the default one
-	// obviously and it uses the two lists of hardware IDs specified down here
+	// obviously and it uses the two lists of hardware IDs specified down here.
 	HardwareDiscoveryStrategy string `json:"hardwareDiscoveryStrategy,omitempty"`
 	// ControlPlaneHardwareIDs contains a list of hardware IDs used as pool for
 	// control plane kubernetes instances.
@@ -39,10 +39,10 @@ type TinkerbellClusterSpec struct {
 	MachineHardwareIDs []string `json:"machineHardwareIDs,omitempty"`
 }
 
-// TinkerbellClusterStatus defines the observed state of TinkerbellCluster
+// TinkerbellClusterStatus defines the observed state of TinkerbellCluster.
 type TinkerbellClusterStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
+	// Important: Run "make" to regenerate code after modifying this file.
 
 	// Ready denotes that the cluster (infrastructure) is ready.
 	// +optional
@@ -52,7 +52,7 @@ type TinkerbellClusterStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:object:root=true
 
-// TinkerbellCluster is the Schema for the tinkerbellclusters API
+// TinkerbellCluster is the Schema for the tinkerbellclusters API.
 type TinkerbellCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -63,7 +63,7 @@ type TinkerbellCluster struct {
 
 // +kubebuilder:object:root=true
 
-// TinkerbellClusterList contains a list of TinkerbellCluster
+// TinkerbellClusterList contains a list of TinkerbellCluster.
 type TinkerbellClusterList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1alpha3/tinkerbellmachine_types.go
+++ b/api/v1alpha3/tinkerbellmachine_types.go
@@ -31,12 +31,12 @@ const (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// TinkerbellMachineSpec defines the desired state of TinkerbellMachine
+// TinkerbellMachineSpec defines the desired state of TinkerbellMachine.
 type TinkerbellMachineSpec struct {
 	HardwareID string `json:"hardwareReservationID,omitempty"`
 }
 
-// TinkerbellMachineStatus defines the observed state of TinkerbellMachine
+// TinkerbellMachineStatus defines the observed state of TinkerbellMachine.
 type TinkerbellMachineStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -88,7 +88,7 @@ type TinkerbellMachineStatus struct {
 // +kubebuilder:printcolumn:name="InstanceID",type="string",JSONPath=".spec.providerID",description="Tinkerbell instance ID"
 // +kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this TinkerbellMachine"
 
-// TinkerbellMachine is the Schema for the tinkerbellmachines API
+// TinkerbellMachine is the Schema for the tinkerbellmachines API.
 type TinkerbellMachine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -99,7 +99,7 @@ type TinkerbellMachine struct {
 
 // +kubebuilder:object:root=true
 
-// TinkerbellMachineList contains a list of TinkerbellMachine
+// TinkerbellMachineList contains a list of TinkerbellMachine.
 type TinkerbellMachineList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1alpha3/tinkerbellmachinetemplate_types.go
+++ b/api/v1alpha3/tinkerbellmachinetemplate_types.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// TinkerbellMachineTemplateSpec defines the desired state of TinkerbellMachineTemplate
+// TinkerbellMachineTemplateSpec defines the desired state of TinkerbellMachineTemplate.
 type TinkerbellMachineTemplateSpec struct {
 	Template TinkerbellMachineTemplateResource `json:"template"`
 }
@@ -29,7 +29,7 @@ type TinkerbellMachineTemplateSpec struct {
 // +kubebuilder:resource:path=tinkerbellmachinetemplates,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
 
-// TinkerbellMachineTemplate is the Schema for the tinkerbellmachinetemplates API
+// TinkerbellMachineTemplate is the Schema for the tinkerbellmachinetemplates API.
 type TinkerbellMachineTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -39,7 +39,7 @@ type TinkerbellMachineTemplate struct {
 
 // +kubebuilder:object:root=true
 
-// TinkerbellMachineTemplateList contains a list of TinkerbellMachineTemplate
+// TinkerbellMachineTemplateList contains a list of TinkerbellMachineTemplate.
 type TinkerbellMachineTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -27,7 +27,7 @@ var (
 	TinkerbellResourceStatusSuccess = TinkerbellResourceStatus(4)
 )
 
-// TinkerbellMachineTemplateResource describes the data needed to create am TinkerbellMachine from a template
+// TinkerbellMachineTemplateResource describes the data needed to create am TinkerbellMachine from a template.
 type TinkerbellMachineTemplateResource struct {
 	// Spec is the specification of the desired behavior of the machine.
 	Spec TinkerbellMachineSpec `json:"spec"`

--- a/controllers/tinkerbellcluster_controller.go
+++ b/controllers/tinkerbellcluster_controller.go
@@ -19,6 +19,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -56,7 +57,8 @@ func (r *TinkerbellClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{}, err
+
+		return ctrl.Result{}, fmt.Errorf("getting cluster: %w", err)
 	}
 
 	logger = logger.WithName(tcluster.APIVersion)
@@ -64,11 +66,12 @@ func (r *TinkerbellClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result
 	// Fetch the Machine.
 	cluster, err := util.GetOwnerCluster(ctx, r.Client, tcluster.ObjectMeta)
 	if err != nil {
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("getting owner cluster: %w", err)
 	}
 
 	if cluster == nil {
 		logger.Info("OwnerCluster is not set yet. Requeuing...")
+
 		return ctrl.Result{
 			Requeue:      true,
 			RequeueAfter: 2 * time.Second,

--- a/controllers/tinkerbellcluster_controller.go
+++ b/controllers/tinkerbellcluster_controller.go
@@ -50,7 +50,7 @@ func (r *TinkerbellClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result
 	ctx := context.Background()
 	logger := r.Log.WithValues("tinkerbellcluster", req.NamespacedName)
 
-	// your logic here
+	// Your logic here.
 	tcluster := &infrastructurev1alpha3.TinkerbellCluster{}
 	if err := r.Get(ctx, req.NamespacedName, tcluster); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -80,7 +80,7 @@ func (r *TinkerbellClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result
 		return ctrl.Result{}, nil
 	}
 
-	// Handle deleted clusters
+	// Handle deleted clusters.
 	if !cluster.DeletionTimestamp.IsZero() {
 		return r.reconcileDelete()
 	}
@@ -96,7 +96,7 @@ func (r *TinkerbellClusterReconciler) reconcileDelete() (ctrl.Result, error) {
 	// Initially I created this handler to remove an elastic IP when a cluster
 	// gets delete, but it does not sound like a good idea.  It is better to
 	// leave to the users the ability to decide if they want to keep and resign
-	// the IP or if they do not need it anymore
+	// the IP or if they do not need it anymore.
 	return ctrl.Result{}, nil
 }
 
@@ -112,7 +112,7 @@ func (r *TinkerbellClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-// MachineNotFound error representing that the requested device was not yet found
+// MachineNotFound error representing that the requested device was not yet found.
 type MachineNotFound struct {
 	err string
 }
@@ -121,7 +121,7 @@ func (e *MachineNotFound) Error() string {
 	return e.err
 }
 
-// MachineNoIP error representing that the requested device does not have an IP yet assigned
+// MachineNoIP error representing that the requested device does not have an IP yet assigned.
 type MachineNoIP struct {
 	err string
 }

--- a/controllers/tinkerbellcluster_controller.go
+++ b/controllers/tinkerbellcluster_controller.go
@@ -80,6 +80,7 @@ func (r *TinkerbellClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result
 
 	if util.IsPaused(cluster, tcluster) {
 		logger.Info("TinkerbellCluster or linked Cluster is marked as paused. Won't reconcile")
+
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/tinkerbellcluster_controller.go
+++ b/controllers/tinkerbellcluster_controller.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	"github.com/tinkerbell/cluster-api-provider-tinkerbell/api/v1alpha3"
 	infrastructurev1alpha3 "github.com/tinkerbell/cluster-api-provider-tinkerbell/api/v1alpha3"
 )
 
@@ -89,7 +88,7 @@ func (r *TinkerbellClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result
 	return r.reconcileNormal(tcluster)
 }
 
-func (r *TinkerbellClusterReconciler) reconcileNormal(tcluster *v1alpha3.TinkerbellCluster) (ctrl.Result, error) {
+func (r *TinkerbellClusterReconciler) reconcileNormal(tcluster *infrastructurev1alpha3.TinkerbellCluster) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/tinkerbellcluster_controller.go
+++ b/controllers/tinkerbellcluster_controller.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package controllers contains Cluster API controllers for Tinkerbell.
 package controllers
 
 import (

--- a/main.go
+++ b/main.go
@@ -48,7 +48,6 @@ func init() {
 }
 
 func main() {
-
 	var (
 		enableLeaderElection    bool
 		leaderElectionNamespace string
@@ -140,6 +139,7 @@ func main() {
 			setupLog.Error(err, "unable to create controller", "controller", "TinkerbellCluster")
 			os.Exit(1)
 		}
+
 		if err = (&controllers.TinkerbellMachineReconciler{
 			Client:   mgr.GetClient(),
 			Log:      ctrl.Log.WithName("controllers").WithName("TinkerbellMachine"),
@@ -167,6 +167,7 @@ func main() {
 	}
 
 	setupLog.Info("starting manager")
+
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	//TODO: get a tinkerell client
+	// TODO: Get a Tinkerbell client.
 
 	if webhookPort == 0 {
 		if err = (&controllers.TinkerbellClusterReconciler{


### PR DESCRIPTION
## Description

Fix some linter issue found by `golangci-lint`. There is still couple outstanding, which are not trivial to fix, as they require adding documentation or refactoring and I'm not that familiar with the code yet.

## Why is this needed

To make code more consistent and easier to read.

## How Has This Been Tested?

Run `golangci-lint run --enable-all --disable=godox,lll,testpackage,goerr113,gci,exhaustivestruct,gochecknoglobals,gomnd
,gochecknoinits --max-same-issues=0 --max-issues-per-linter=0 --build-tags integration,e2e --timeout 10m --exclude-use-default=false --sort-results ./...` and see there is less warnings than on `main` branch.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [x] provided instructions on how to upgrade
