### PR TITLE
main.go: fix leader election ID

### DIFF
--- a/main.go
+++ b/main.go
@@ -122,7 +122,7 @@ func main() {
 		Port:                    webhookPort,
 		EventBroadcaster:        broadcaster,
 		LeaderElection:          enableLeaderElection,
-		LeaderElectionID:        "controller-leader-election-capp",
+		LeaderElectionID:        "controller-leader-election-capt",
 		LeaderElectionNamespace: leaderElectionNamespace,
 		Namespace:               watchNamespace,
 		SyncPeriod:              &syncPeriod,


### PR DESCRIPTION
Leftover from porting from CAPP.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>
