### PR TITLE
Update cluster-api checkout directions in developer docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -90,7 +90,7 @@ kubectl config get-contexts  | awk '/^*/ {print $2}'
 
 Then, run the following commands to clone code we're going to run:
 ```sh
-git clone https://github.com/kubernetes-sigs/cluster-api -b release-0.3
+git clone https://github.com/kubernetes-sigs/cluster-api
 git clone git@github.com:tinkerbell/cluster-api-provider-tink.git
 cd ../cluster-api
 ```


### PR DESCRIPTION
## Description

Updates the checkout directions to align with latest v1alpha4 updates

## Why is this needed

Current HEAD is aligned with v1alpha4, using the current developer directions results in trying to spin up a tilt cluster using cluster-api v0.3.x/v1alpha3

